### PR TITLE
Add Selenium and Playwright Google login examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pkl
+*state.json
+playwright*.zip

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # webTesting
-Some test cases on Web Testing using PlayWright and Selenium, especially Personalized Testing.
+
+This repository demonstrates simple Selenium and Playwright scripts that log into Google
+using a username and password, perform a search, and store session data so
+subsequent runs skip the login step.
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+playwright install  # downloads browsers for Playwright
+```
+
+Set environment variables with your credentials:
+
+```bash
+export GOOGLE_USER="you@example.com"
+export GOOGLE_PASS="your_password"
+```
+
+Use a test account without 2FA. Google may block automated logins.
+
+## Running the scripts
+
+- **Selenium**: `python selenium_google.py`
+- **Playwright**: `python playwright_google.py`
+
+Each script saves authentication state (`selenium_cookies.pkl` or
+`playwright_state.json`) so later executions can reuse the session.

--- a/playwright_google.py
+++ b/playwright_google.py
@@ -1,0 +1,36 @@
+import os
+import asyncio
+from pathlib import Path
+from playwright.async_api import async_playwright
+
+EMAIL = os.getenv("GOOGLE_USER")
+PASSWORD = os.getenv("GOOGLE_PASS")
+STATE_FILE = Path("playwright_state.json")
+
+async def login_and_search():
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=False)
+        context = await browser.new_context(
+            storage_state=STATE_FILE if STATE_FILE.exists() else None
+        )
+        page = await context.new_page()
+        await page.goto("https://www.google.com")
+
+        if "Sign in" in await page.content():
+            await page.get_by_text("Sign in").click()
+            await page.fill("input[type='email']", EMAIL)
+            await page.press("input[type='email']", "Enter")
+            await page.fill("input[type='password']", PASSWORD)
+            await page.press("input[type='password']", "Enter")
+            await page.wait_for_load_state("networkidle")
+            await context.storage_state(path=STATE_FILE)
+
+        await page.fill("input[name='q']", "web automation with Playwright")
+        await page.press("input[name='q']", "Enter")
+        await page.wait_for_selector("#search")
+        await browser.close()
+
+if __name__ == "__main__":
+    if not EMAIL or not PASSWORD:
+        raise EnvironmentError("Please set GOOGLE_USER and GOOGLE_PASS environment variables")
+    asyncio.run(login_and_search())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+selenium
+playwright

--- a/selenium_google.py
+++ b/selenium_google.py
@@ -1,0 +1,46 @@
+import os
+import pickle
+import time
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+EMAIL = os.getenv("GOOGLE_USER")
+PASSWORD = os.getenv("GOOGLE_PASS")
+COOKIE_FILE = "selenium_cookies.pkl"
+
+def load_cookies(driver):
+    """Load cookies if previously saved."""
+    driver.get("https://www.google.com")
+    if os.path.exists(COOKIE_FILE):
+        for cookie in pickle.load(open(COOKIE_FILE, "rb")):
+            driver.add_cookie(cookie)
+        driver.refresh()
+
+def save_cookies(driver):
+    """Persist cookies to disk."""
+    pickle.dump(driver.get_cookies(), open(COOKIE_FILE, "wb"))
+
+
+def login_and_search():
+    driver = webdriver.Chrome()
+    load_cookies(driver)
+    # If not already signed in, log in
+    if "Sign in" in driver.page_source:
+        driver.find_element(By.LINK_TEXT, "Sign in").click()
+        driver.find_element(By.ID, "identifierId").send_keys(EMAIL, Keys.ENTER)
+        time.sleep(2)
+        driver.find_element(By.NAME, "password").send_keys(PASSWORD, Keys.ENTER)
+        time.sleep(3)
+        save_cookies(driver)
+    # Perform a search
+    search = driver.find_element(By.NAME, "q")
+    search.send_keys("web automation with selenium", Keys.ENTER)
+    time.sleep(5)
+    driver.quit()
+
+
+if __name__ == "__main__":
+    if not EMAIL or not PASSWORD:
+        raise EnvironmentError("Please set GOOGLE_USER and GOOGLE_PASS environment variables")
+    login_and_search()


### PR DESCRIPTION
## Summary
- add Selenium script demonstrating Google login, cookie reuse, and search
- add Playwright script demonstrating Google login, storage-state reuse, and search
- document setup, credential handling, and script usage

## Testing
- `python -m py_compile selenium_google.py playwright_google.py`


------
https://chatgpt.com/codex/tasks/task_e_68967dd9a7308332b72aad056518578b